### PR TITLE
Kotlinify MissingXmlHeader and add quick fix option.

### DIFF
--- a/lint-rules-android-lint/src/main/java/com/vanniktech/lintrules/android/MissingXmlHeaderDetector.kt
+++ b/lint-rules-android-lint/src/main/java/com/vanniktech/lintrules/android/MissingXmlHeaderDetector.kt
@@ -3,6 +3,7 @@ package com.vanniktech.lintrules.android
 import com.android.tools.lint.detector.api.Category.Companion.CORRECTNESS
 import com.android.tools.lint.detector.api.Implementation
 import com.android.tools.lint.detector.api.Issue
+import com.android.tools.lint.detector.api.Location
 import com.android.tools.lint.detector.api.ResourceXmlDetector
 import com.android.tools.lint.detector.api.Scope.Companion.RESOURCE_FILE_SCOPE
 import com.android.tools.lint.detector.api.Severity.WARNING
@@ -10,13 +11,22 @@ import com.android.tools.lint.detector.api.XmlContext
 import org.w3c.dom.Document
 
 @JvmField val ISSUE_MISSING_XML_HEADER = Issue.create("MissingXmlHeader",
-    "Missing Xml header.", "The xml file is missing the xml header.", CORRECTNESS, 5, WARNING,
-    Implementation(MissingXmlHeaderDetector::class.java, RESOURCE_FILE_SCOPE))
+  "Missing Xml header.", "The xml file is missing the xml header.", CORRECTNESS, 5, WARNING,
+  Implementation(MissingXmlHeaderDetector::class.java, RESOURCE_FILE_SCOPE))
 
 class MissingXmlHeaderDetector : ResourceXmlDetector() {
   override fun visitDocument(context: XmlContext, document: Document) {
-    if (!context.file.readText().startsWith("<?xml")) {
-      context.report(ISSUE_MISSING_XML_HEADER, document, context.getLocation(document), "Missing the xml header.")
+    val content = context.client.readFile(context.file)
+
+    if (!content.startsWith("<?xml")) {
+      val fix = fix()
+        .replace()
+        .name("Add xml header")
+        .text(content.toString())
+        .with("<?xml version=\"1.0\" encoding=\"utf-8\"?>\n$content")
+        .build()
+
+      context.report(ISSUE_MISSING_XML_HEADER, document, Location.create(context.file, content, 0, content.length), "Missing an xml header.", fix)
     }
   }
 }


### PR DESCRIPTION
Fixes #51 as we'll have initial support for this and add further changes later.