### PR TITLE
Support JUnit5's Disabled annotation in `IgnoreWithoutReasonDetector`

### DIFF
--- a/lint-rules-android-lint/src/main/java/com/vanniktech/lintrules/android/IgnoreWithoutReasonDetector.kt
+++ b/lint-rules-android-lint/src/main/java/com/vanniktech/lintrules/android/IgnoreWithoutReasonDetector.kt
@@ -21,6 +21,8 @@ val ISSUE_IGNORE_WITHOUT_REASON = Issue.create("IgnoreWithoutReason",
     CORRECTNESS, PRIORITY, WARNING,
     Implementation(IgnoreWithoutReasonDetector::class.java, EnumSet.of(Scope.JAVA_FILE, Scope.TEST_SOURCES)))
 
+val ANNOTATIONS = listOf("Ignore", "Disabled")
+
 class IgnoreWithoutReasonDetector : Detector(), Detector.UastScanner {
   override fun getApplicableUastTypes(): List<Class<out UElement>> = listOf(UMethod::class.java, UClass::class.java)
 
@@ -34,8 +36,8 @@ class IgnoreWithoutReasonDetector : Detector(), Detector.UastScanner {
     private fun processAnnotations(element: UElement, modifierListOwner: UAnnotated) {
       val annotations = context.evaluator.getAllAnnotations(modifierListOwner, false)
 
-      // Do the verification if only we have "Ignore" annotation.
-      annotations.firstOrNull { it.qualifiedName?.split(".")?.lastOrNull() == "Ignore" }?.let {
+      // Do the verification if only we have "Ignore" or "Disabled" annotation.
+      annotations.firstOrNull { it.qualifiedName?.split(".")?.lastOrNull() in ANNOTATIONS }?.let {
         if (it.findDeclaredAttributeValue("value")?.getValueIfStringLiteral().isNullOrBlank()) {
           context.report(ISSUE_IGNORE_WITHOUT_REASON, element, context.getLocation(it), "Test is ignored without given any explanation.")
         }

--- a/lint-rules-android-lint/src/test/java/com/vanniktech/lintrules/android/IgnoreWithoutReasonDetectorTest.kt
+++ b/lint-rules-android-lint/src/test/java/com/vanniktech/lintrules/android/IgnoreWithoutReasonDetectorTest.kt
@@ -22,7 +22,7 @@ class IgnoreWithoutReasonDetectorTest {
         .expectClean()
   }
 
-  @Test fun annotationWithReasonOnFunction() {
+  @Test fun ignoreAnnotationWithReasonOnFunction() {
     lint()
         .files(stubJUnitTest, stubJUnitIgnore, java("""
               package foo;
@@ -40,7 +40,7 @@ class IgnoreWithoutReasonDetectorTest {
         .expectClean()
   }
 
-  @Test fun annotationWithReasonOnClass() {
+  @Test fun ignoreAnnotationWithReasonOnClass() {
     lint()
         .files(stubJUnitTest, stubJUnitIgnore, java("""
               package foo;
@@ -58,7 +58,7 @@ class IgnoreWithoutReasonDetectorTest {
         .expectClean()
   }
 
-  @Test fun annotationWithoutReasonOnClass() {
+  @Test fun ignoreAnnotationWithoutReasonOnClass() {
     lint()
         .files(stubJUnitTest, stubJUnitIgnore, java("""
               package foo;
@@ -80,7 +80,7 @@ class IgnoreWithoutReasonDetectorTest {
             |0 errors, 1 warnings""".trimMargin())
   }
 
-  @Test fun annotationWithoutReasonOnFunction() {
+  @Test fun ignoreAnnotationWithoutReasonOnFunction() {
     lint()
         .files(stubJUnitTest, stubJUnitIgnore, java("""
               package foo;
@@ -99,6 +99,86 @@ class IgnoreWithoutReasonDetectorTest {
             |src/foo/MyTest.java:7: Warning: Test is ignored without given any explanation. [IgnoreWithoutReason]
             |  @Test @Ignore fun something() {
             |        ~~~~~~~
+            |0 errors, 1 warnings""".trimMargin())
+  }
+
+  @Test fun disabledAnnotationWithReasonOnFunction() {
+    lint()
+        .files(stubJUnitTest, stubJUnitIgnore, java("""
+              package foo;
+
+              import org.junit.jupiter.api.Disabled;
+              import org.junit.jupiter.api.Test;
+
+              class MyTest {
+                @Test @Disabled("reason") fun something() {
+                }
+              }""").indented()
+        )
+        .issues(ISSUE_IGNORE_WITHOUT_REASON)
+        .run()
+        .expectClean()
+  }
+
+  @Test fun disabledAnnotationWithReasonOnClass() {
+    lint()
+        .files(stubJUnitTest, stubJUnitIgnore, java("""
+              package foo;
+
+              import org.junit.jupiter.api.Disabled;
+              import org.junit.jupiter.api.Test;
+
+              @Disabled("reason") class MyTest {
+                @Test fun something() {
+                }
+              }""").indented()
+        )
+        .issues(ISSUE_IGNORE_WITHOUT_REASON)
+        .run()
+        .expectClean()
+  }
+
+  @Test fun disabledAnnotationWithoutReasonOnClass() {
+    lint()
+        .files(stubJUnitTest, stubJUnitIgnore, java("""
+              package foo;
+
+              import org.junit.jupiter.api.Disabled;
+              import org.junit.jupiter.api.Test;
+
+              @Disabled class MyTest {
+                @Test fun something() {
+                }
+              }""").indented()
+        )
+        .issues(ISSUE_IGNORE_WITHOUT_REASON)
+        .run()
+        .expect("""
+            |src/foo/MyTest.java:6: Warning: Test is ignored without given any explanation. [IgnoreWithoutReason]
+            |@Disabled class MyTest {
+            |~~~~~~~~~
+            |0 errors, 1 warnings""".trimMargin())
+  }
+
+  @Test fun disabledAnnotationWithoutReasonOnFunction() {
+    lint()
+        .files(stubJUnitTest, stubJUnitIgnore, java("""
+              package foo;
+
+              import org.junit.jupiter.api.Disabled;
+              import org.junit.jupiter.api.Test;
+
+              class MyTest {
+                @Test @Disabled fun something() {
+                }
+              }""").indented()
+        )
+        .issues(ISSUE_IGNORE_WITHOUT_REASON)
+        .run()
+        .expect("""
+            |src/foo/MyTest.java:7: Warning: Test is ignored without given any explanation. [IgnoreWithoutReason]
+            |  @Test @Disabled fun something() {
+            |        ~~~~~~~~~
             |0 errors, 1 warnings""".trimMargin())
   }
 }


### PR DESCRIPTION
Support JUnit5's Disabled annotation in `IgnoreWithoutReasonDetector`

**Considerations:**
Considered changing the error message etc but thought it would be an overkill. It is quite clear what to expect when the error message is seen although it says `ignored`. WDYT?

Options are: 
- Leave as it is
- Dynamic message
- Have `Ignore/Disabled` together.

**Tests:**
For the tests, tried parameterized tests to do them without copy&paste
But found this one is better since their error message is also different because of the different length of the annotations and also import statements.