### PR TITLE
Always expect underscored resourcePrefix by forcing it if needed.

### DIFF
--- a/lint-rules-android-lint/src/main/java/com/vanniktech/lintrules/android/WrongLayoutNameDetector.kt
+++ b/lint-rules-android-lint/src/main/java/com/vanniktech/lintrules/android/WrongLayoutNameDetector.kt
@@ -21,7 +21,7 @@ val ISSUE_WRONG_LAYOUT_NAME = Issue.create("WrongLayoutName",
 
 class WrongLayoutNameDetector : LayoutDetector() {
   override fun visitDocument(context: XmlContext, document: Document) {
-    val modified = allowedPrefixes.map { context.project.resourcePrefix() + it }
+    val modified = allowedPrefixes.map { context.project.resourcePrefix().forceUnderscoreIfNeeded() + it }
     val doesNotStartWithPrefix = modified.none { context.file.name.startsWith(it) }
     val notEquals = modified.map { it.dropLast(1) }.none { context.file.name == "$it.xml" }
 
@@ -30,5 +30,7 @@ class WrongLayoutNameDetector : LayoutDetector() {
     }
   }
 }
+
+private fun String.forceUnderscoreIfNeeded() = if (isNotEmpty() && !endsWith("_")) plus("_") else this
 
 fun Project.resourcePrefix() = if (isGradleProject) computeResourcePrefix(gradleProjectModel).orEmpty() else ""

--- a/lint-rules-android-lint/src/test/java/com/vanniktech/lintrules/android/WrongLayoutNameDetectorTest.kt
+++ b/lint-rules-android-lint/src/test/java/com/vanniktech/lintrules/android/WrongLayoutNameDetectorTest.kt
@@ -22,6 +22,14 @@ class WrongLayoutNameDetectorTest {
         .expectClean()
   }
 
+  @Test fun activityFileWithResourcePrefixWithNoEndingUnderscore() {
+    lint()
+      .files(xml("res/layout/unit_test_prefix_activity_home.xml", "<merge/>"), resourcePrefix("unit_test_prefix"))
+      .issues(ISSUE_WRONG_LAYOUT_NAME)
+      .run()
+      .expectClean()
+  }
+
   @Test fun layoutMatchesExactly() {
     lint()
         .files(xml("res/layout/calculator_view.xml", "<merge/>"), resourcePrefix("calculator_"))
@@ -46,6 +54,16 @@ class WrongLayoutNameDetectorTest {
         .issues(ISSUE_WRONG_LAYOUT_NAME)
         .run()
         .expect("""
+          |res/layout/random.xml: Warning: Layout does not start with one of the following prefixes: unit_test_prefix_activity_, unit_test_prefix_view_, unit_test_prefix_fragment_, unit_test_prefix_dialog_, unit_test_prefix_bottom_sheet_, unit_test_prefix_adapter_item_, unit_test_prefix_divider_, unit_test_prefix_space_, unit_test_prefix_popup_window_ [WrongLayoutName]
+          |0 errors, 1 warnings""".trimMargin())
+  }
+
+  @Test fun randomLayoutFileWithResourcePrefixWithNoEndingUnderscore() {
+    lint()
+      .files(xml("res/layout/random.xml", "<merge/>"), resourcePrefix("unit_test_prefix"))
+      .issues(ISSUE_WRONG_LAYOUT_NAME)
+      .run()
+      .expect("""
           |res/layout/random.xml: Warning: Layout does not start with one of the following prefixes: unit_test_prefix_activity_, unit_test_prefix_view_, unit_test_prefix_fragment_, unit_test_prefix_dialog_, unit_test_prefix_bottom_sheet_, unit_test_prefix_adapter_item_, unit_test_prefix_divider_, unit_test_prefix_space_, unit_test_prefix_popup_window_ [WrongLayoutName]
           |0 errors, 1 warnings""".trimMargin())
   }


### PR DESCRIPTION
In one of my projects, I decided to add `resourcePrefix` with no underscore and I started to get `WrongLayoutName` warnings.

These changes will make the rule slightly less strict and allow non-ending underscored resourcePrefixes. I.e. 'module_prefix', 'module_prefix_' are both ok.

- Added 2 new tests