### PR TITLE
Make id detector lintFix more intelligent

### DIFF
--- a/lint-rules-android-lint/src/main/java/com/vanniktech/lintrules/android/MatchingIdFixer.kt
+++ b/lint-rules-android-lint/src/main/java/com/vanniktech/lintrules/android/MatchingIdFixer.kt
@@ -1,0 +1,18 @@
+package com.vanniktech.lintrules.android
+
+import com.android.tools.lint.detector.api.XmlContext
+
+class MatchingIdFixer(context: XmlContext, private val id: String) {
+  private val layoutName = context.file.name.replace(".xml", "")
+  val expectedPrefix = layoutName.toLowerCamelCase()
+
+  fun needsFix() = !id.startsWith(expectedPrefix)
+
+  fun fixedId(): String {
+    return if (id.startsWith(expectedPrefix, ignoreCase = true)) {
+      expectedPrefix + id.substring(expectedPrefix.length)
+    } else {
+      expectedPrefix + id.capitalize()
+    }
+  }
+}

--- a/lint-rules-android-lint/src/main/java/com/vanniktech/lintrules/android/MatchingMenuIdDetector.kt
+++ b/lint-rules-android-lint/src/main/java/com/vanniktech/lintrules/android/MatchingMenuIdDetector.kt
@@ -25,26 +25,18 @@ class MatchingMenuIdDetector : ResourceXmlDetector() {
   override fun getApplicableAttributes() = listOf(ATTR_ID)
 
   override fun visitAttribute(context: XmlContext, attribute: Attr) {
-    val fileName = context.file.name.replace(".xml", "").toLowerCamelCase()
     val id = stripIdPrefix(attribute.value)
+    val fixer = MatchingIdFixer(context, id)
 
-    if (!id.startsWith(fileName)) {
+    if (fixer.needsFix()) {
       val fix = fix()
           .replace()
           .text(id)
-          .with(toBeReplaced(fileName, id))
+          .with(fixer.fixedId())
           .autoFix()
           .build()
 
-      context.report(ISSUE_MATCHING_MENU_ID, attribute, context.getValueLocation(attribute), "Id should start with: $fileName", fix)
-    }
-  }
-
-  private fun toBeReplaced(fileName: String, id: String): String {
-    return if (id.startsWith(fileName, ignoreCase = true)) {
-      fileName + id.substring(fileName.length)
-    } else {
-      fileName + id.capitalize()
+      context.report(ISSUE_MATCHING_MENU_ID, attribute, context.getValueLocation(attribute), "Id should start with: ${fixer.expectedPrefix}", fix)
     }
   }
 }

--- a/lint-rules-android-lint/src/main/java/com/vanniktech/lintrules/android/MatchingMenuIdDetector.kt
+++ b/lint-rules-android-lint/src/main/java/com/vanniktech/lintrules/android/MatchingMenuIdDetector.kt
@@ -3,16 +3,12 @@ package com.vanniktech.lintrules.android
 import com.android.SdkConstants.ATTR_ID
 import com.android.resources.ResourceFolderType
 import com.android.resources.ResourceFolderType.MENU
+import com.android.tools.lint.detector.api.*
 import com.android.tools.lint.detector.api.Category.Companion.CORRECTNESS
-import com.android.tools.lint.detector.api.Implementation
-import com.android.tools.lint.detector.api.Issue
-import com.android.tools.lint.detector.api.ResourceXmlDetector
 import com.android.tools.lint.detector.api.Scope.Companion.RESOURCE_FILE_SCOPE
 import com.android.tools.lint.detector.api.Severity.WARNING
-import com.android.tools.lint.detector.api.XmlContext
-import com.android.tools.lint.detector.api.stripIdPrefix
 import org.w3c.dom.Attr
-import java.util.EnumSet
+import java.util.*
 
 val ISSUE_MATCHING_MENU_ID = Issue.create("MatchingMenuId", "Flags menu ids that don't match with the file name.",
     "When the layout file is named menu_home all of the containing ids should be prefixed with menuHome to avoid ambiguity between different menu files across different menu items.",
@@ -32,11 +28,19 @@ class MatchingMenuIdDetector : ResourceXmlDetector() {
       val fix = fix()
           .replace()
           .text(id)
-          .with(fileName)
+          .with(toBeReplaced(fileName, id))
           .autoFix()
           .build()
 
       context.report(ISSUE_MATCHING_MENU_ID, attribute, context.getValueLocation(attribute), "Id should start with: $fileName", fix)
+    }
+  }
+
+  private fun toBeReplaced(fileName: String, id: String): String {
+    return if (id.startsWith(fileName, ignoreCase = true)) {
+      fileName + id.substring(fileName.length)
+    } else {
+      fileName + id.capitalize()
     }
   }
 }

--- a/lint-rules-android-lint/src/main/java/com/vanniktech/lintrules/android/MatchingMenuIdDetector.kt
+++ b/lint-rules-android-lint/src/main/java/com/vanniktech/lintrules/android/MatchingMenuIdDetector.kt
@@ -3,12 +3,16 @@ package com.vanniktech.lintrules.android
 import com.android.SdkConstants.ATTR_ID
 import com.android.resources.ResourceFolderType
 import com.android.resources.ResourceFolderType.MENU
-import com.android.tools.lint.detector.api.*
 import com.android.tools.lint.detector.api.Category.Companion.CORRECTNESS
+import com.android.tools.lint.detector.api.Implementation
+import com.android.tools.lint.detector.api.Issue
+import com.android.tools.lint.detector.api.ResourceXmlDetector
 import com.android.tools.lint.detector.api.Scope.Companion.RESOURCE_FILE_SCOPE
 import com.android.tools.lint.detector.api.Severity.WARNING
+import com.android.tools.lint.detector.api.XmlContext
+import com.android.tools.lint.detector.api.stripIdPrefix
 import org.w3c.dom.Attr
-import java.util.*
+import java.util.EnumSet
 
 val ISSUE_MATCHING_MENU_ID = Issue.create("MatchingMenuId", "Flags menu ids that don't match with the file name.",
     "When the layout file is named menu_home all of the containing ids should be prefixed with menuHome to avoid ambiguity between different menu files across different menu items.",

--- a/lint-rules-android-lint/src/main/java/com/vanniktech/lintrules/android/MatchingViewIdDetector.kt
+++ b/lint-rules-android-lint/src/main/java/com/vanniktech/lintrules/android/MatchingViewIdDetector.kt
@@ -1,14 +1,10 @@
 package com.vanniktech.lintrules.android
 
 import com.android.SdkConstants.ATTR_ID
+import com.android.tools.lint.detector.api.*
 import com.android.tools.lint.detector.api.Category.Companion.CORRECTNESS
-import com.android.tools.lint.detector.api.Implementation
-import com.android.tools.lint.detector.api.Issue
-import com.android.tools.lint.detector.api.LayoutDetector
 import com.android.tools.lint.detector.api.Scope.Companion.RESOURCE_FILE_SCOPE
 import com.android.tools.lint.detector.api.Severity.WARNING
-import com.android.tools.lint.detector.api.XmlContext
-import com.android.tools.lint.detector.api.stripIdPrefix
 import org.w3c.dom.Attr
 
 val ISSUE_MATCHING_VIEW_ID = Issue.create("MatchingViewId", "Flags view ids that don't match with the file name.",
@@ -28,11 +24,19 @@ class MatchingViewIdDetector : LayoutDetector() {
       val fix = fix()
           .replace()
           .text(id)
-          .with(fileName)
+          .with(toBeReplaced(fileName, id))
           .autoFix()
           .build()
 
       context.report(ISSUE_MATCHING_VIEW_ID, attribute, context.getValueLocation(attribute), "Id should start with: $fileName", fix)
+    }
+  }
+
+  private fun toBeReplaced(fileName: String, id: String): String {
+    return if (id.startsWith(fileName, ignoreCase = true)) {
+      fileName + id.substring(fileName.length)
+    } else {
+      fileName + id.capitalize()
     }
   }
 }

--- a/lint-rules-android-lint/src/main/java/com/vanniktech/lintrules/android/MatchingViewIdDetector.kt
+++ b/lint-rules-android-lint/src/main/java/com/vanniktech/lintrules/android/MatchingViewIdDetector.kt
@@ -1,10 +1,14 @@
 package com.vanniktech.lintrules.android
 
 import com.android.SdkConstants.ATTR_ID
-import com.android.tools.lint.detector.api.*
 import com.android.tools.lint.detector.api.Category.Companion.CORRECTNESS
+import com.android.tools.lint.detector.api.Implementation
+import com.android.tools.lint.detector.api.Issue
+import com.android.tools.lint.detector.api.LayoutDetector
 import com.android.tools.lint.detector.api.Scope.Companion.RESOURCE_FILE_SCOPE
 import com.android.tools.lint.detector.api.Severity.WARNING
+import com.android.tools.lint.detector.api.XmlContext
+import com.android.tools.lint.detector.api.stripIdPrefix
 import org.w3c.dom.Attr
 
 val ISSUE_MATCHING_VIEW_ID = Issue.create("MatchingViewId", "Flags view ids that don't match with the file name.",

--- a/lint-rules-android-lint/src/test/java/com/vanniktech/lintrules/android/MatchingMenuIdDetectorTest.kt
+++ b/lint-rules-android-lint/src/test/java/com/vanniktech/lintrules/android/MatchingMenuIdDetectorTest.kt
@@ -16,6 +16,28 @@ class MatchingMenuIdDetectorTest {
         .expectClean()
   }
 
+  @Test
+  fun idWithoutPrefix() {
+    lint()
+      .files(xml("res/menu/menu_main.xml", """
+            <menu xmlns:android="http://schemas.android.com/apk/res/android">
+              <item android:id="@+id/something"/>
+            </menu>""").indented())
+      .issues(ISSUE_MATCHING_MENU_ID)
+      .run()
+      .expect("""
+            |res/menu/menu_main.xml:2: Warning: Id should start with: menuMain [MatchingMenuId]
+            |  <item android:id="@+id/something"/>
+            |                    ~~~~~~~~~~~~~~
+            |0 errors, 1 warnings""".trimMargin())
+      .expectFixDiffs("""
+            |Fix for res/menu/menu_main.xml line 2: Replace with menuMainSomething:
+            |@@ -2 +2
+            |-   <item android:id="@+id/something"/>
+            |+   <item android:id="@+id/menuMainSomething"/>
+            |""".trimMargin())
+  }
+
   @Test fun idAndroidMainWrongOrder() {
     lint()
         .files(xml("res/menu/menu_main.xml", """
@@ -30,10 +52,10 @@ class MatchingMenuIdDetectorTest {
             |                    ~~~~~~~~~~~~~~~~~~~~~~
             |0 errors, 1 warnings""".trimMargin())
         .expectFixDiffs("""
-            |Fix for res/menu/menu_main.xml line 2: Replace with menuMain:
+            |Fix for res/menu/menu_main.xml line 2: Replace with menuMainMainMenuSomething:
             |@@ -2 +2
             |-   <item android:id="@+id/mainMenuSomething"/>
-            |+   <item android:id="@+id/menuMain"/>
+            |+   <item android:id="@+id/menuMainMainMenuSomething"/>
             |""".trimMargin())
   }
 
@@ -62,10 +84,10 @@ class MatchingMenuIdDetectorTest {
             |                    ~~~~~~~~~~~~~~~~~~~~~
             |0 errors, 1 warnings""".trimMargin())
         .expectFixDiffs("""
-            |Fix for res/menu/menu_main.xml line 2: Replace with menuMain:
+            |Fix for res/menu/menu_main.xml line 2: Replace with menuMainTextView:
             |@@ -2 +2
             |-   <item android:id="@+id/MenuMainTextView"/>
-            |+   <item android:id="@+id/menuMain"/>
+            |+   <item android:id="@+id/menuMainTextView"/>
             |""".trimMargin())
   }
 
@@ -83,10 +105,10 @@ class MatchingMenuIdDetectorTest {
             |                    ~~~~~~~~~~~~~~~~~~~~~
             |0 errors, 1 warnings""".trimMargin())
         .expectFixDiffs("""
-            |Fix for res/menu/view_custom.xml line 2: Replace with viewCustom:
+            |Fix for res/menu/view_custom.xml line 2: Replace with viewCustomMainViewTextView:
             |@@ -2 +2
             |-   <item android:id="@+id/mainViewTextView"/>
-            |+   <item android:id="@+id/viewCustom"/>
+            |+   <item android:id="@+id/viewCustomMainViewTextView"/>
             |""".trimMargin())
   }
 

--- a/lint-rules-android-lint/src/test/java/com/vanniktech/lintrules/android/MatchingViewIdDetectorTest.kt
+++ b/lint-rules-android-lint/src/test/java/com/vanniktech/lintrules/android/MatchingViewIdDetectorTest.kt
@@ -14,6 +14,27 @@ class MatchingViewIdDetectorTest {
         .expectClean()
   }
 
+  @Test
+  fun idWithoutPrefix() {
+    lint()
+      .files(xml("res/layout/activity_main.xml", """
+            <TextView xmlns:android="http://schemas.android.com/apk/res/android" android:id="@+id/text"/>""").indented())
+      .issues(ISSUE_MATCHING_VIEW_ID)
+      .run()
+      .expect("""
+            |res/layout/activity_main.xml:1: Warning: Id should start with: activityMain [MatchingViewId]
+            |<TextView xmlns:android="http://schemas.android.com/apk/res/android" android:id="@+id/text"/>
+            |                                                                                 ~~~~~~~~~
+            |0 errors, 1 warnings""".trimMargin())
+      .expectFixDiffs("""
+            |Fix for res/layout/activity_main.xml line 1: Replace with activityMainText:
+            |@@ -1 +1
+            |- <TextView xmlns:android="http://schemas.android.com/apk/res/android" android:id="@+id/text"/>
+            |@@ -2 +1
+            |+ <TextView xmlns:android="http://schemas.android.com/apk/res/android" android:id="@+id/activityMainText"/>
+            |""".trimMargin())
+  }
+
   @Test fun idAndroidActivityWrongOrder() {
     lint()
         .files(xml("res/layout/activity_main.xml", """
@@ -26,11 +47,11 @@ class MatchingViewIdDetectorTest {
             |                                                                                 ~~~~~~~~~~~~~~~~~~~~~~~~~
             |0 errors, 1 warnings""".trimMargin())
         .expectFixDiffs("""
-            |Fix for res/layout/activity_main.xml line 1: Replace with activityMain:
+            |Fix for res/layout/activity_main.xml line 1: Replace with activityMainMainActivityTextView:
             |@@ -1 +1
             |- <TextView xmlns:android="http://schemas.android.com/apk/res/android" android:id="@+id/mainActivityTextView"/>
             |@@ -2 +1
-            |+ <TextView xmlns:android="http://schemas.android.com/apk/res/android" android:id="@+id/activityMain"/>
+            |+ <TextView xmlns:android="http://schemas.android.com/apk/res/android" android:id="@+id/activityMainMainActivityTextView"/>
             |""".trimMargin())
   }
 
@@ -55,11 +76,11 @@ class MatchingViewIdDetectorTest {
             |                                                                                 ~~~~~~~~~~~~~~~~~~~~~~~
             |0 errors, 1 warnings""".trimMargin())
         .expectFixDiffs("""
-            |Fix for res/layout/view_custom.xml line 1: Replace with viewCustom:
+            |Fix for res/layout/view_custom.xml line 1: Replace with viewCustomTextView:
             |@@ -1 +1
             |- <TextView xmlns:android="http://schemas.android.com/apk/res/android" android:id="@+id/ViewCustomTextView"/>
             |@@ -2 +1
-            |+ <TextView xmlns:android="http://schemas.android.com/apk/res/android" android:id="@+id/viewCustom"/>
+            |+ <TextView xmlns:android="http://schemas.android.com/apk/res/android" android:id="@+id/viewCustomTextView"/>
             |""".trimMargin())
   }
 
@@ -75,11 +96,11 @@ class MatchingViewIdDetectorTest {
             |                                                                                 ~~~~~~~~~~~~~~~~~~~~~
             |0 errors, 1 warnings""".trimMargin())
         .expectFixDiffs("""
-            |Fix for res/layout/view_custom.xml line 1: Replace with viewCustom:
+            |Fix for res/layout/view_custom.xml line 1: Replace with viewCustomMainViewTextView:
             |@@ -1 +1
             |- <TextView xmlns:android="http://schemas.android.com/apk/res/android" android:id="@+id/mainViewTextView"/>
             |@@ -2 +1
-            |+ <TextView xmlns:android="http://schemas.android.com/apk/res/android" android:id="@+id/viewCustom"/>
+            |+ <TextView xmlns:android="http://schemas.android.com/apk/res/android" android:id="@+id/viewCustomMainViewTextView"/>
             |""".trimMargin())
   }
 


### PR DESCRIPTION
The MatchingId checks that ids start with certain prefix. 

## Problem 

The current fix replaces all the wrong ids with the fileName prefix, loosing the original ids. This fix breaks compilation in majority of the times. After this point it becomes impossible to remember which id was which. 

## Solution

Keep the original id and just add the prefix as a solution. 

It is currently checks if there are casing issues and fixes them too. But it does not fix wrong order issues. `mainMenuSomething` will become `menuMainMainMenuSomething`. If you can think of any simple solution to this, I would be glad to do it. The solutions I came up were either complex or has problems with edge cases.

Fixes #284 