### PR TITLE
RxJava2MethodMissingCheckReturnValueDetector: Observable with nested generics

### DIFF
--- a/lint-rules-rxjava2-lint/src/main/java/com/vanniktech/lintrules/rxjava2/RxJava2MethodMissingCheckReturnValueDetector.kt
+++ b/lint-rules-rxjava2-lint/src/main/java/com/vanniktech/lintrules/rxjava2/RxJava2MethodMissingCheckReturnValueDetector.kt
@@ -62,7 +62,7 @@ class RxJava2MethodMissingCheckReturnValueDetector : Detector(), Detector.UastSc
 
     private fun isTypeThatRequiresAnnotation(psiType: PsiType): Boolean {
       val canonicalText = psiType.canonicalText
-          .replace("<[\\w.]*>".toRegex(), "") // We need to remove the generics.
+          .replace("<[\\w.<>]*>".toRegex(), "") // We need to remove the generics.
 
       return canonicalText.matches("io\\.reactivex\\.[\\w]+".toRegex()) ||
           "io.reactivex.disposables.Disposable" == canonicalText ||

--- a/lint-rules-rxjava2-lint/src/test/java/com/vanniktech/lintrules/rxjava2/RxJava2MethodMissingCheckReturnValueDetectorTest.kt
+++ b/lint-rules-rxjava2-lint/src/test/java/com/vanniktech/lintrules/rxjava2/RxJava2MethodMissingCheckReturnValueDetectorTest.kt
@@ -419,4 +419,49 @@ class RxJava2MethodMissingCheckReturnValueDetectorTest {
         .run()
         .expectClean()
   }
+
+  @Test fun methodReturningObservableListMissingCheckReturnValue() {
+    lint()
+        .files(rxJava2(), java("""
+          package foo;
+
+          import io.reactivex.Observable;
+
+          class Example {
+            private Observable<List<Object>> foo() {
+              return null;
+            }
+          }""").indented())
+        .issues(ISSUE_METHOD_MISSING_CHECK_RETURN_VALUE)
+        .run()
+        .expect("""
+          |src/foo/Example.java:6: Warning: Method should have @CheckReturnValue annotation. [RxJava2MethodMissingCheckReturnValue]
+          |  private Observable<List<Object>> foo() {
+          |                                   ~~~
+          |0 errors, 1 warnings""".trimMargin())
+        .expectFixDiffs("""
+          |Fix for src/foo/Example.java line 5: Add @CheckReturnValue:
+          |@@ -6 +6
+          |-   private Observable<List<Object>> foo() {
+          |+   @io.reactivex.annotations.CheckReturnValue private Observable<List<Object>> foo() {
+          |""".trimMargin())
+  }
+
+  @Test fun methodReturningObservableListHavingCheckReturnValue() {
+    lint()
+        .files(rxJava2(), java("""
+          package foo;
+
+          import io.reactivex.Observable;
+          import io.reactivex.annotations.CheckReturnValue;
+
+          class Example {
+            @CheckReturnValue public Observable<List<Object>> foo() {
+              return null;
+            }
+          }""").indented())
+        .issues(ISSUE_METHOD_MISSING_CHECK_RETURN_VALUE)
+        .run()
+        .expectClean()
+  }
 }


### PR DESCRIPTION
RxJava2MethodMissingCheckReturnValueDetector doesn't warn the method returning Observable with nested generics , like `Observable<List<Object>>`