### PR TITLE
Update readme to use lintChecks.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ A set of very opinionated lint rules.
 ## Android Lint Rules
 
 ```groovy
-compile 'com.vanniktech:lint-rules-android:0.13.0'
-compile 'com.vanniktech:lint-rules-android:0.14.0-SNAPSHOT'
+lintChecks 'com.vanniktech:lint-rules-android:0.13.0'
+lintChecks 'com.vanniktech:lint-rules-android:0.14.0-SNAPSHOT'
 ```
 
 - **AlertDialogUsage** - Support library AlertDialog is much more powerful and plays better together with the new theming / styling than the AlertDialog built into the framework.
@@ -47,8 +47,8 @@ compile 'com.vanniktech:lint-rules-android:0.14.0-SNAPSHOT'
 ## RxJava 2 Lint Rules
 
 ```groovy
-compile 'com.vanniktech:lint-rules-rxjava2:0.13.0'
-compile 'com.vanniktech:lint-rules-rxjava2:0.14.0-SNAPSHOT'
+lintChecks 'com.vanniktech:lint-rules-rxjava2:0.13.0'
+lintChecks 'com.vanniktech:lint-rules-rxjava2:0.14.0-SNAPSHOT'
 ```
 
 - **RxJava2DefaultScheduler** - Calling this method will rely on a default scheduler. This is not necessary the best default. Being explicit and taking the overload for passing one is preferred.


### PR DESCRIPTION
`compile` is deprecated and would also cause your lint checks to be shipped with your app :D