### PR TITLE
Do not use UElement as PsiElement

### DIFF
--- a/lint-rules-android-lint/src/main/kotlin/com/vanniktech/lintrules/android/LayoutFileNameMatchesClassDetector.kt
+++ b/lint-rules-android-lint/src/main/kotlin/com/vanniktech/lintrules/android/LayoutFileNameMatchesClassDetector.kt
@@ -10,6 +10,7 @@ import com.android.tools.lint.detector.api.Issue
 import com.android.tools.lint.detector.api.JavaContext
 import com.android.tools.lint.detector.api.Scope.JAVA_FILE
 import com.android.tools.lint.detector.api.Severity.WARNING
+import com.android.tools.lint.detector.api.nameFromSource
 import com.intellij.psi.PsiMethod
 import org.jetbrains.uast.UCallExpression
 import org.jetbrains.uast.getContainingUClass
@@ -48,7 +49,7 @@ class LayoutFileNameMatchesClassDetector :
       ?.name
 
     val className = node.getContainingUClass()
-      ?.name
+      ?.nameFromSource
 
     if (isNoLayoutReference || layoutFileName == null || className == null) {
       return

--- a/lint-rules-rxjava2-lint/src/main/kotlin/com/vanniktech/lintrules/rxjava2/RxJava2MethodMissingCheckReturnValueDetector.kt
+++ b/lint-rules-rxjava2-lint/src/main/kotlin/com/vanniktech/lintrules/rxjava2/RxJava2MethodMissingCheckReturnValueDetector.kt
@@ -40,17 +40,17 @@ class RxJava2MethodMissingCheckReturnValueDetector :
   class CheckReturnValueVisitor(private val context: JavaContext) : UElementHandler() {
     override fun visitMethod(node: UMethod) {
       val returnType = node.returnType
-      val isPropertyFunction = node.language is KotlinLanguage && node.sourcePsi is KtProperty
+      val isPropertyFunction = node.lang is KotlinLanguage && node.sourcePsi is KtProperty
 
       if (returnType != null && isTypeThatRequiresAnnotation(returnType) && !isPropertyFunction) {
         val hasAnnotatedMethod = context.evaluator.getAllAnnotations(node as UAnnotated, true)
           .any { "io.reactivex.annotations.CheckReturnValue" == it.qualifiedName }
         if (hasAnnotatedMethod) return
 
-        val hasIgnoredModifier = ignoredModifiers().any { node.hasModifier(it) }
+        val hasIgnoredModifier = ignoredModifiers().any { node.javaPsi.hasModifier(it) }
         if (hasIgnoredModifier) return
 
-        val modifier = node.modifierList.children.joinToString(separator = " ") { it.text }
+        val modifier = node.javaPsi.modifierList.children.joinToString(separator = " ") { it.text }
 
         val fix = LintFix.create()
           .replace()

--- a/lint-rules-rxjava2-lint/src/main/kotlin/com/vanniktech/lintrules/rxjava2/RxJava2MissingCompositeDisposableClearDetector.kt
+++ b/lint-rules-rxjava2-lint/src/main/kotlin/com/vanniktech/lintrules/rxjava2/RxJava2MissingCompositeDisposableClearDetector.kt
@@ -10,6 +10,8 @@ import com.android.tools.lint.detector.api.Issue
 import com.android.tools.lint.detector.api.JavaContext
 import com.android.tools.lint.detector.api.Scope.JAVA_FILE
 import com.android.tools.lint.detector.api.Severity.ERROR
+import com.android.tools.lint.detector.api.nameFromSource
+import com.android.tools.lint.detector.api.typeFromPsi
 import org.jetbrains.uast.UCallExpression
 import org.jetbrains.uast.UClass
 import org.jetbrains.uast.UExpression
@@ -40,14 +42,14 @@ class RxJava2MissingCompositeDisposableClearDetector :
   ) : UElementHandler() {
     override fun visitClass(node: UClass) {
       val compositeDisposables = node.fields
-        .filter { "io.reactivex.disposables.CompositeDisposable" == it.type.canonicalText }
+        .filter { "io.reactivex.disposables.CompositeDisposable" == it.typeFromPsi?.canonicalText }
         .toMutableSet()
 
       fun remove(node: UExpression?) {
         val iterator = compositeDisposables.iterator()
 
         while (iterator.hasNext()) {
-          if (node?.skipParenthesizedExprDown()?.asRenderString() == iterator.next().name) {
+          if (node?.skipParenthesizedExprDown()?.asRenderString() == iterator.next().nameFromSource) {
             iterator.remove()
           }
         }

--- a/lint.xml
+++ b/lint.xml
@@ -3,7 +3,6 @@
   <issue id="UnknownNullness">
     <ignore regexp=".*"/>
   </issue>
-  <issue id="UElementAsPsi" severity="ignore"/>
   <!-- Our pace. -->
   <issue id="GradleDependency" severity="ignore" in="cli,gradle"/>
   <issue id="NewerVersionAvailable" severity="ignore" in="cli,gradle"/>


### PR DESCRIPTION
...as per the request at https://issuetracker.google.com/issues/437005994

All warnings suppressed are valid, not false positives. This commit clarifies those usages with either upstream Lint level utils or direct uses of proper PsiElement counterparts (in UElement).